### PR TITLE
configured apt for the debian snapshot corresponding to R-2.15.1-4

### DIFF
--- a/binary/2.15.1/Dockerfile
+++ b/binary/2.15.1/Dockerfile
@@ -1,16 +1,29 @@
-## Install from debian:7 (wheezy), R 2.15.1
+## debian wheezy - debian snapshot 20130310 ~ 2.15.1-4
+FROM debian:wheezy
 
-FROM debian:7
-RUN apt-get update  && apt-get install -y --no-install-recommends \
-    r-base \
-    r-base-dev \
-    r-recommended \
-    vim-tiny \
-    wget 
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak
+RUN echo \
+	deb http://snapshot.debian.org/archive/debian/20130310 wheezy main \
+	 >> /etc/apt/sources.list && echo \
+	deb http://snapshot.debian.org/archive/debian-security/20130310 wheezy/updates main \
+	>> /etc/apt/sources.list && \
+	apt-get -o Acquire::Check-Valid-Until=false update
 
-## Set a default user. Available via runtime flag `--user docker` 
+RUN apt-get install -y --no-install-recommends \
+	ed \
+	less \
+	r-base \
+	r-recommended \
+	vim-tiny \
+	wget \
+	nano
+
+
+## Set a default user. Available via runtime flag `--user docker`
 ## and add user to 'staff' group, granting them write privileges
 ## to /usr/local/lib/R/site.library
 RUN useradd docker
+# no addgroup in wheezy
+#RUN addgroup docker staff
 
 

--- a/binary/2.15.1/Makefile
+++ b/binary/2.15.1/Makefile
@@ -1,0 +1,10 @@
+NAME=r-base-2.15.1
+
+all: build
+
+build: 
+	docker build -t $(NAME) .
+
+
+run: build
+	docker run -ti $(NAME) bash


### PR DESCRIPTION
Proof of concept of using debian snapshot.
Some hints:
- use the same debian version that in the snapshot (look at dists/ dir)
- use apt-get -o Acquire::Check-Valid-Until=false update to update apt
