### PR TITLE
Move base image to `debian:stretch` (Debian 9.0, release 2017-06-17) for 3.4.0, latest, and devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ image            | description                               | size   | metrics 
 
 This repository provides alternate stack to `r-base`, `rocker/rstudio`, `rocker/hadleyverse` series, with an emphasis on reproducibility.  Compared to those images, this stack:
 
-- builds on the stable `debian:jessie` release instead of `debian:testing`, so no more apt-get breaking when debian:testing repos are updated and you had to muck with `-t unstable` to get apt-get to work.  
+- builds on debian stable (`debian:jessie` for versions < 3.4.0, `debian:stretch` thereafter) release instead of `debian:testing`, so no more apt-get breaking when debian:testing repos are updated and you had to muck with `-t unstable` to get apt-get to work.  
 - Further, this stack installs a fixed version of R itself from source, rather than whatever is already packaged for Debian (the r-base stack gets the latest R version as a binary from debian:unstable), 
 - and it installs all R packages from a fixed snapshot of CRAN at a given date (MRAN repos).
 - provides images that are generally smaller than the r-base series
@@ -54,7 +54,7 @@ image            |  Dockerfiles
 
 These images are actively maintained.  This means that while an effort is made to preserve the general function of these images over time, both these Dockerfiles and the resulting images are subject to some change over time.  In particular:
 
-- Images are regularly re-built on Docker Hub whenever their base image changes, starting with changes to `debian` Docker image.  This is the rough equivalent of running `apt-get upgrade` on `debian:jessie`, since all `apt-get` commands are re-run and will pull in the most current sources.  This allows the images to receive security updates to any packages installed from the `debian:jessie` repositories, but will not in general change the versions of any software and is very unlikely to break anything.
+- Images are regularly re-built on Docker Hub whenever their base image changes, starting with changes to `debian` Docker image.  This is the rough equivalent of running `apt-get upgrade` on `debian`, since all `apt-get` commands are re-run and will pull in the most current sources.  This allows the images to receive security updates to any packages installed from the `debian` repositories, but will not in general change the versions of any software and is very unlikely to break anything.
 
 - The Dockerfiles themselves are subject to change, to improve performance, ease of use, readability, or other concerns raised in the issues.  These changes should also not alter the general behavior of R or R packages on the image.  These changes can be seen in the git history.  The [rocker-versioned](https://github.com/rocker-org/rocker-versioned) repo will use its own semantic version tagging to indicate changes to this repository, with snapshots from these tags archived on Zenodo.
 

--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -25,12 +25,12 @@ RUN apt-get update \
     gsfonts \
     libbz2-1.0 \
     libcurl3 \
-    libicu52 \
+    libicu57 \
     libjpeg62-turbo \
     libopenblas-dev \
     libpangocairo-1.0-0 \
     libpcre3 \
-    libpng12-0 \
+    libpng16-16 \
     libtiff5 \
     liblzma5 \
     locales \
@@ -57,8 +57,8 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
-    tcl8.5-dev \
-    tk8.5-dev \
+    tcl8.6-dev \
+    tk8.6-dev \
     texinfo \
     texlive-extra-utils \
     texlive-fonts-recommended \

--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \

--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -119,6 +119,9 @@ RUN apt-get update \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## TEMPORARY WORKAROUND to get more robust error handling for install2.r prior to littler update
+  && curl -O /usr/local/bin/install2.r https://github.com/eddelbuettel/littler/raw/master/inst/examples/install2.r \
+  && chmod +x /usr/local/bin/install2.r \
   ## Clean up from R source install
   && cd / \
   && rm -rf /tmp/* \

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -24,12 +24,12 @@ RUN apt-get update \
     gsfonts \
     libbz2-1.0 \
     libcurl3 \
-    libicu52 \
+    libicu57 \
     libjpeg62-turbo \
     libopenblas-dev \
     libpangocairo-1.0-0 \
     libpcre3 \
-    libpng12-0 \
+    libpng16-16 \
     libtiff5 \
     liblzma5 \
     locales \
@@ -56,8 +56,8 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
-    tcl8.5-dev \
-    tk8.5-dev \
+    tcl8.6-dev \
+    tk8.6-dev \
     texinfo \
     texlive-extra-utils \
     texlive-fonts-recommended \

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -118,6 +118,9 @@ RUN apt-get update \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## TEMPORARY WORKAROUND to get more robust error handling for install2.r prior to littler update
+  && curl -O /usr/local/bin/install2.r https://github.com/eddelbuettel/littler/raw/master/inst/examples/install2.r \
+  && chmod +x /usr/local/bin/install2.r \
   ## Clean up from R source install
   && cd / \
   && rm -rf /tmp/* \

--- a/r-ver/Makefile
+++ b/r-ver/Makefile
@@ -16,7 +16,7 @@ sync: devel/Dockerfile 3.4.0/Dockerfile
 
 devel/Dockerfile: Dockerfile
 	cp Dockerfile devel/Dockerfile 
-	sed -i 's/tcl8\.5-dev/subversion tcl8\.5-dev/' devel/Dockerfile
+	sed -i 's/tcl8\.6-dev/subversion tcl8.6-dev/' devel/Dockerfile
 	sed -i 's/curl -O .*\.gz/svn co https:\/\/svn\.r-project.org\/R\/trunk R-devel/' devel/Dockerfile
 	sed -i 's/.*tar -xf R-.*//' devel/Dockerfile
 	sed -i 's/cd R-.*/cd R-devel \\/' devel/Dockerfile

--- a/r-ver/Makefile
+++ b/r-ver/Makefile
@@ -5,11 +5,24 @@ latest:
 	docker build --build-arg R_VERSION=${LATEST} -t rocker/r-ver .	
 
 ## Auto-generate separate Dockerfiles for auto builds by hub
-sync: 3.3.3/Dockerfile 3.4.0/Dockerfile 3.3.2/Dockerfile 3.3.1/Dockerfile 3.3.0/Dockerfile 3.2.0/Dockerfile 3.1.0/Dockerfile
+sync: devel/Dockerfile 3.4.0/Dockerfile
 
 
 3.4.0/Dockerfile: Dockerfile
 	export R_VERSION=3.4.0 && unset BUILD_DATE && make update
+
+
+## Custom configuration for devel 
+
+devel/Dockerfile: Dockerfile
+	cp Dockerfile devel/Dockerfile 
+	sed -i 's/tcl8\.5-dev/subversion tcl8\.5-dev/' devel/Dockerfile
+	sed -i 's/curl -O .*\.gz/svn co https:\/\/svn\.r-project.org\/R\/trunk R-devel/' devel/Dockerfile
+	sed -i 's/.*tar -xf R-.*//' devel/Dockerfile
+	sed -i 's/cd R-.*/cd R-devel \\/' devel/Dockerfile
+
+####### These are frozen now to debian:jessie images and should not be updated further!
+
 3.3.3/Dockerfile: Dockerfile
 	export R_VERSION=3.3.3 && export BUILD_DATE=2017-04-21 && make update
 3.3.2/Dockerfile: Dockerfile

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
-    tcl8.6-dev \
+    subversion tcl8.6-dev \
     tk8.6-dev \
     texinfo \
     texlive-extra-utils \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -1,9 +1,16 @@
-FROM debian:jessie
+FROM debian:stretch
 
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ARG R_VERSION
 ARG BUILD_DATE
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV TERM xterm
+ENV R_VERSION=${R_VERSION:-3.4.0} \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    TERM=xterm
 
 ## dependencies
 RUN apt-get update \
@@ -49,8 +56,7 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
-    subversion \
-    tcl8.5-dev \
+    subversion tcl8.5-dev \
     tk8.5-dev \
     texinfo \
     texlive-extra-utils \
@@ -66,6 +72,8 @@ RUN apt-get update \
   && cd tmp/ \
   ## Download source code
   && svn co https://svn.r-project.org/R/trunk R-devel \
+  ## Extract source code
+
   && cd R-devel \
   ## Set compiler flags
   && R_PAPERSIZE=letter \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -24,12 +24,12 @@ RUN apt-get update \
     gsfonts \
     libbz2-1.0 \
     libcurl3 \
-    libicu52 \
+    libicu57 \
     libjpeg62-turbo \
     libopenblas-dev \
     libpangocairo-1.0-0 \
     libpcre3 \
-    libpng12-0 \
+    libpng16-16 \
     libtiff5 \
     liblzma5 \
     locales \
@@ -56,8 +56,8 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
-    subversion tcl8.5-dev \
-    tk8.5-dev \
+    tcl8.6-dev \
+    tk8.6-dev \
     texinfo \
     texlive-extra-utils \
     texlive-fonts-recommended \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -118,6 +118,9 @@ RUN apt-get update \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## TEMPORARY WORKAROUND to get more robust error handling for install2.r prior to littler update
+  && curl -O /usr/local/bin/install2.r https://github.com/eddelbuettel/littler/raw/master/inst/examples/install2.r \
+  && chmod +x /usr/local/bin/install2.r \
   ## Clean up from R source install
   && cd / \
   && rm -rf /tmp/* \

--- a/rstudio/3.4.0/Dockerfile
+++ b/rstudio/3.4.0/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update \
     psmisc \
     python-setuptools \
     sudo \
-    wget \ 
+    wget \
+  && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb \
+  && dpkg -i libssl1.0.0.deb \
+  && rm libssl1.0.0.deb \
   && RSTUDIO_LATEST=$(wget --no-check-certificate -qO- https://s3.amazonaws.com/rstudio-server/current.ver) \
   && [ -z "$RSTUDIO_VERSION" ] && RSTUDIO_VERSION=$RSTUDIO_LATEST || true \
   && wget -q http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update \
     psmisc \
     python-setuptools \
     sudo \
-    wget \ 
+    wget \
+  && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb \
+  && dpkg -i libssl1.0.0.deb \
+  && rm libssl1.0.0.deb \
   && RSTUDIO_LATEST=$(wget --no-check-certificate -qO- https://s3.amazonaws.com/rstudio-server/current.ver) \
   && [ -z "$RSTUDIO_VERSION" ] && RSTUDIO_VERSION=$RSTUDIO_LATEST || true \
   && wget -q http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \

--- a/rstudio/Makefile
+++ b/rstudio/Makefile
@@ -1,5 +1,5 @@
 latest: 
-	docker build --build-arg RSTUDIO_VERSION=1.0.44 -t rocker/rstudio .
+	docker build -t rocker/rstudio .
 
 ## Example with build-arg
 #	docker build --build-arg RSTUDIO_VERSION=1.0.44 -t rocker/rstudio .

--- a/rstudio/Makefile
+++ b/rstudio/Makefile
@@ -5,8 +5,9 @@ latest:
 #	docker build --build-arg RSTUDIO_VERSION=1.0.44 -t rocker/rstudio .
 
 sync: 
-	make devel/Dockerfile 3.*/Dockerfile
+	make devel/Dockerfile 3.4.0/Dockerfile
 
+## DO NOT SYNC versions older than 3.4.0, they are frozen to jessie
 
 ## FIXME consider locking RSTUDIO_VERSION and/or PANDOC_VERSION based on release date as well
 

--- a/rstudio/devel/Dockerfile
+++ b/rstudio/devel/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update \
     psmisc \
     python-setuptools \
     sudo \
-    wget \ 
+    wget \
+  && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb \
+  && dpkg -i libssl1.0.0.deb \
+  && rm libssl1.0.0.deb \
   && RSTUDIO_LATEST=$(wget --no-check-certificate -qO- https://s3.amazonaws.com/rstudio-server/current.ver) \
   && [ -z "$RSTUDIO_VERSION" ] && RSTUDIO_VERSION=$RSTUDIO_LATEST || true \
   && wget -q http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \

--- a/tidyverse/Makefile
+++ b/tidyverse/Makefile
@@ -2,12 +2,15 @@ latest:
 	docker build -t rocker/tidyverse .
 
 sync: 
-	make devel/Dockerfile 3.4.0/Dockerfile 3.3.3/Dockerfile 3.3.2/Dockerfile 3.3.1/Dockerfile
+	make devel/Dockerfile 3.4.0/Dockerfile 
 
 devel/Dockerfile: Dockerfile
 	export R_VERSION=devel && make update
 3.4.0/Dockerfile: Dockerfile
 	export R_VERSION=3.4.0 && make update
+
+## Older Dockerfiles remain based on jessie, do not sync
+
 3.3.3/Dockerfile: Dockerfile
 	export R_VERSION=3.3.3 && make update
 3.3.2/Dockerfile: Dockerfile

--- a/verse/3.4.0/Dockerfile
+++ b/verse/3.4.0/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update \
   && mktexlsr \
   && updmap-sys \
   ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
-  && install2.r --error --repos http://rforge.net PKI \
+  && install2.r -r http://rforge.net PKI \
   ## And some nice R packages for publishing-related stuff
-  && install2.r --error --repos $MRAN --deps TRUE \
+  && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 

--- a/verse/3.4.0/Dockerfile
+++ b/verse/3.4.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     qpdf \
     ## for git via ssh key 
     ssh \
-    ## for building pdfs via pandoc/LaTeX
+    ## for building pdfs via pandoc/LaTeX (These are large!)
     lmodern \
     texlive-fonts-recommended \
     texlive-generic-recommended \
@@ -47,14 +47,13 @@ RUN apt-get update \
   && echo "Map zi4.map" >> /usr/share/texlive/texmf-dist/web2c/updmap.cfg \
   && mktexlsr \
   && updmap-sys \
-  ## And some nice R packages for publishing-related stuff 
-  && . /etc/environment \ 
+  ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
+  && install2.r --error --repos http://rforge.net PKI \
+  ## And some nice R packages for publishing-related stuff
   && install2.r --error --repos $MRAN --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 
-# - libv8-dev (Javascript V8 packages)
 # - yihui/printr R package (when released to CRAN)
-# - jags 4.2 (build from source, repo version too old and apt-tagging forces upgrade of all compiler libs)
 # - libgsl0-dev (GSL math library dependencies)
-# - librdf ?
+# - librdf0-dev

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update \
   && mktexlsr \
   && updmap-sys \
   ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
-  && install2.r --error --repos http://rforge.net PKI \
+  && install2.r -r http://rforge.net PKI \
   ## And some nice R packages for publishing-related stuff
-  && install2.r --error --repos $MRAN --deps TRUE \
+  && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     qpdf \
     ## for git via ssh key 
     ssh \
-    ## for building pdfs via pandoc/LaTeX
+    ## for building pdfs via pandoc/LaTeX (These are large!)
     lmodern \
     texlive-fonts-recommended \
     texlive-generic-recommended \
@@ -47,13 +47,13 @@ RUN apt-get update \
   && echo "Map zi4.map" >> /usr/share/texlive/texmf-dist/web2c/updmap.cfg \
   && mktexlsr \
   && updmap-sys \
-  ## And some nice R packages for publishing-related stuff 
-  && . /etc/environment \ 
+  ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
+  && install2.r --error --repos http://rforge.net PKI \
+  ## And some nice R packages for publishing-related stuff
   && install2.r --error --repos $MRAN --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 
 # - yihui/printr R package (when released to CRAN)
-# - jags 4.2 (build from source, repo version too old and apt-tagging forces upgrade of all compiler libs)
 # - libgsl0-dev (GSL math library dependencies)
-# - librdf0
+# - librdf0-dev

--- a/verse/Makefile
+++ b/verse/Makefile
@@ -2,12 +2,15 @@ latest:
 	docker build -t rocker/verse .
 
 sync: 
-	make devel/Dockerfile 3.*.*/Dockerfile
+	make devel/Dockerfile 3.4.0/Dockerfile
 
 devel/Dockerfile: Dockerfile
 	export R_VERSION=devel && make update
 3.4.0/Dockerfile: Dockerfile
 	export R_VERSION=3.4.0 && make update
+
+## Do not sync older Dockerfiles
+
 3.3.3/Dockerfile: Dockerfile
 	export R_VERSION=3.3.3 && make update
 3.3.2/Dockerfile: Dockerfile

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update \
   && mktexlsr \
   && updmap-sys \
   ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
-  && install2.r --error --repos http://rforge.net PKI \
+  && install2.r -r http://rforge.net PKI \
   ## And some nice R packages for publishing-related stuff
-  && install2.r --error --repos $MRAN --deps TRUE \
+  && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     qpdf \
     ## for git via ssh key 
     ssh \
-    ## for building pdfs via pandoc/LaTeX
+    ## for building pdfs via pandoc/LaTeX (These are large!)
     lmodern \
     texlive-fonts-recommended \
     texlive-generic-recommended \
@@ -47,14 +47,13 @@ RUN apt-get update \
   && echo "Map zi4.map" >> /usr/share/texlive/texmf-dist/web2c/updmap.cfg \
   && mktexlsr \
   && updmap-sys \
-  ## And some nice R packages for publishing-related stuff 
-  && . /etc/environment \ 
+  ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
+  && install2.r --error --repos http://rforge.net PKI \
+  ## And some nice R packages for publishing-related stuff
   && install2.r --error --repos $MRAN --deps TRUE \
     bookdown rticles rmdshower
 
 ## Consider including: 
-# - libv8-dev (Javascript V8 packages)
 # - yihui/printr R package (when released to CRAN)
-# - jags 4.2 (build from source, repo version too old and apt-tagging forces upgrade of all compiler libs)
 # - libgsl0-dev (GSL math library dependencies)
-# - librdf ?
+# - librdf0-dev


### PR DESCRIPTION
Moves the base image in `r-ver` and subsequent stack to `debian:stretch` (Debian 9.0, release 2017-06-17) for the `3.4.0`, `latest`, and `devel` tags.  Makefiles will no longer sync changes made int the Dockerfile `latest` back to the Dockerfiles of older versions.  Those Dockerfiles are now stable and not expected to change further. 

Most users should be unaffected by this change.  Downstream Dockerfiles will benefit from newer versions of libraries and compilers, which will make certain packages easier to install on Docker (e.g. `jags` and `GDAL` libraries no longer need to be compiled from source since `stretch` binaries provide sufficiently recent CRAN versions).