### PR TITLE
Added libreadline7 to apt package installs

### DIFF
--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     libpangocairo-1.0-0 \
     libpcre3 \
     libpng16-16 \
+    libreadline7 \
     libtiff5 \
     liblzma5 \
     locales \

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     libpangocairo-1.0-0 \
     libpcre3 \
     libpng16-16 \
+    libreadline7 \
     libtiff5 \
     liblzma5 \
     locales \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     libpangocairo-1.0-0 \
     libpcre3 \
     libpng16-16 \
+    libreadline7 \
     libtiff5 \
     liblzma5 \
     locales \


### PR DESCRIPTION
When attempting to run `r-ver` interactively by running
```
docker run --it rocker/r-ver:latest
```
Results in the following error:
```
/usr/local/lib/R/bin/exec/R: error while loading shared libraries: libreadline.so.7: cannot open shared object file: No such file or directory
```
This error has also reproduced with `rocker/r-ver:3.4.0` but does not appear to be affecting the older tags which are based off Debian Jessie and not Stretch. Including [libreadline7][1] in the images appears to fix the bug.

I'm unsure if the change needs to be made to the Dockerfile for 3.4.0 since it appears in the Makefile that the main r-ver Dockerfile gets copied.

[1]: https://packages.debian.org/stretch/libreadline7