### PR TITLE
the PATH should be protected

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update \
     \nif(is.na(Sys.getenv("HTTR_LOCALHOST", unset=NA))) { \
     \n  options(httr_oob_default = TRUE) \
     \n}' >> /usr/local/lib/R/etc/Rprofile.site \
-  && echo "PATH=\"${PATH}\"" >> /usr/local/lib/R/etc/Renviron \
+  && echo "PATH=\"\${PATH}\"" >> /usr/local/lib/R/etc/Renviron \
   ## Need to configure non-root user for RStudio
   && useradd rstudio \
   && echo "rstudio:rstudio" | chpasswd \


### PR DESCRIPTION
[`&& echo "PATH=\"${PATH}\"" >> /usr/local/lib/R/etc/Renviron`](https://github.com/rocker-org/rocker-versioned/blob/master/rstudio/Dockerfile#L52) results in a fixed environment variable : 

```
PATH="/usr/lib/rstudio-server/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```
I guess it's the same issue as https://github.com/rocker-org/rocker/issues/198 . The `${PATH}` should be protected by adding a `\`.