### PR TITLE
switchable Blas implementations for R

### DIFF
--- a/r-ver/3.1.0/Dockerfile
+++ b/r-ver/3.1.0/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.2.0/Dockerfile
+++ b/r-ver/3.2.0/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.2.5/Dockerfile
+++ b/r-ver/3.2.5/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.3.0/Dockerfile
+++ b/r-ver/3.3.0/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.3.1/Dockerfile
+++ b/r-ver/3.3.1/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.3.2/Dockerfile
+++ b/r-ver/3.3.2/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.3.3/Dockerfile
+++ b/r-ver/3.3.3/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu52 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu57 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.4.1/Dockerfile
+++ b/r-ver/3.4.1/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu57 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/3.4.2/Dockerfile
+++ b/r-ver/3.4.2/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu57 \
@@ -93,7 +94,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu57 \
@@ -92,7 +93,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install

--- a/r-ver/devel-san/Dockerfile
+++ b/r-ver/devel-san/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update -qq \
     xvfb \
     zlib1g-dev \
   && cd /tmp \
-  && svn co https://svn.r-project.org/R/trunk R-devel \ 
+  && svn co https://svn.r-project.org/R/trunk R-devel \
 ## Build and install according the standard 'recipe' I emailed/posted years ago
 ## Updated compiler flags to match https://www.stats.ox.ac.uk/pub/bdr/memtests/README.txt
   && cd /tmp/R-devel \
@@ -85,8 +85,7 @@ RUN apt-get update -qq \
      FC="gfortran" \
      F77="gfortran" \
      ./configure --enable-R-shlib \
-               --without-blas \
-               --without-lapack \
+               --with-blas \
                --with-readline \
                --without-recommended-packages \
                --program-suffix=dev \
@@ -130,7 +129,7 @@ ENV LANG en_US.UTF-8
 
 ## More verbose UBSAN/SAN output (cf #3) -- this is still somewhat speculative
 ## Entry copied from Prof Ripley's setup described at http://www.stats.ox.ac.uk/pub/bdr/memtests/README.txt
-ENV ASAN_OPTIONS 'alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0' 
+ENV ASAN_OPTIONS 'alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0'
 
 
 CMD ["R"]

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     g++ \
     gfortran \
     gsfonts \
+    libblas-dev \
     libbz2-1.0 \
     libcurl3 \
     libicu57 \
@@ -94,7 +95,8 @@ RUN apt-get update \
   ./configure --enable-R-shlib \
                --enable-memory-profiling \
                --with-readline \
-               --with-blas="-lopenblas" \
+               --with-blas \
+               --with-tcltk \
                --disable-nls \
                --without-recommended-packages \
   ## Build and install


### PR DESCRIPTION
As discussed, this installs R using the shared **Blas** system.

It mimics the debian r-base package.
By default it still uses the **openblas** implementation (easy to change if you wish).
It is possible to switch within the docker (prior running R):
```
# switch to libblas
update-alternatives --set libblas.so.3-x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/blas/libblas.so.3
# switch to openBlas
update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libblas.so.3
```

It is also possible to select the implementation when running the docker, e.g.
```
# run R with the libblas
docker run -ti -e LD_LIBRARY_PATH=/usr/lib/libblas  rocker/r-ver
```

If you want to check if it works:
```
%docker run -ti --rm  rocker/r-ver bash
apt-get update && apt-get install lsof
R -q -e "grep('blas', system2('lsof', c('-p', Sys.getpid()), stdout=TRUE), value = TRUE)"

update-alternatives --set libblas.so.3 /usr/lib/libblas/libblas.so.3

R -q -e "grep('blas', system2('lsof', c('-p', Sys.getpid()), stdout=TRUE), value = TRUE)"
```

Also note that I added the "--with-tcltk". This should be basically a no-op, but I find it more explicit, you can know that tcltk support is enabled just at looking at the Dockerfile.


