### PR TITLE
Use TinyTeX for LaTeX libraries

### DIFF
--- a/rstudio/Makefile
+++ b/rstudio/Makefile
@@ -1,0 +1,3 @@
+latest:
+	docker build -t rocker/rstudio .
+

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -36,7 +36,10 @@ RUN apt-get update \
   && wget -qO- \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
-  && ~/.TinyTeX/bin/*/tlmgr path add \
+  && mv ~/.TinyTeX /opt/TinyTeX \
+  && chown -R root:staff /opt/TinyTeX \
+  && chmod g+wx /opt/TinyTeX \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
   && tlmgr path add \
   && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
@@ -44,10 +47,3 @@ RUN apt-get update \
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 
-## Well here's a puzzle! This simple mv call doesn't work in `sh` shell, but works fine in bash shell.
-## Amazingly, /bin/bash -c "mv ~/.TinyTex /opt/TinyTex" doesn't work either, but actually becoming 
-## bash shell first and then running it works fine.  I'm stumped.  
-RUN mv ~/.TinyTeX /opt/TinyTeX \
-  && chown -R root:staff /opt/TinyTeX \
-  && /opt/TinyTeX/bin/*/tlmgr path add
- 

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -45,7 +45,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chmod -R g+w /opt/TinyTeX \
-  && chmod -R g+wx /opt/TinyTex/bin \
+  && chmod -R g+wx /opt/TinyTeX/bin \
  ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update \
   && tlmgr path add \
   && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
-  && chmod -R g+wx /opt/TinyTeX \
+  && chmod -R g+w /opt/TinyTeX \
+  && chmod -R g+wx /opt/TinyTex/bin \
  ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -36,17 +36,18 @@ RUN apt-get update \
   && wget -qO- \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
-    && mv ~/.TinyTex /opt/TinyTex \
-    && chown -R root:staff /opt/TinyTex \
-    && /opt/TinyTeX/bin/*/tlmgr path add \
-    && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-    && tlmgr path add \
-    && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
-  ## And some nice R packages for publishing-related stuff
+  && ~/.TinyTeX/bin/*/tlmgr path add \
+  && tlmgr install metafont mfware inconsolata tex ae parskip listings \
+  && tlmgr path add \
+  && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
+ ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 
-## Consider including: 
-# - yihui/printr R package (when released to CRAN)
-# - libgsl0-dev (GSL math library dependencies)
-# - librdf0-dev
+## Well here's a puzzle! This simple mv call doesn't work in `sh` shell, but works fine in bash shell.
+## Amazingly, /bin/bash -c "mv ~/.TinyTex /opt/TinyTex" doesn't work either, but actually becoming 
+## bash shell first and then running it works fine.  I'm stumped.  
+RUN mv ~/.TinyTex /opt/TinyTex \
+  && chown -R root:staff /opt/TinyTex \
+  && /opt/TinyTeX/bin/*/tlmgr path add
+ 

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
 ## Well here's a puzzle! This simple mv call doesn't work in `sh` shell, but works fine in bash shell.
 ## Amazingly, /bin/bash -c "mv ~/.TinyTex /opt/TinyTex" doesn't work either, but actually becoming 
 ## bash shell first and then running it works fine.  I'm stumped.  
-RUN mv ~/.TinyTeX /opt/TinyTex \
-  && chown -R root:staff /opt/TinyTex \
+RUN mv ~/.TinyTeX /opt/TinyTeX \
+  && chown -R root:staff /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add
  

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -1,7 +1,11 @@
 FROM rocker/tidyverse:latest
 
 ## Add LaTeX, rticles and bookdown support
-RUN apt-get update \
+## uses dummy texlive, see FAQ 8: https://yihui.name/tinytex/faq/
+RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
+  && dpkg -i texlive-local.deb \
+  && rm texlive-local.deb \
+  && apt-get update \
   && apt-get install -y --no-install-recommends \
     ## for rJava
     default-jdk \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -29,8 +29,6 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     qpdf \
     ## for git via ssh key 
     ssh \
-    ## for building pdfs via pandoc/LaTeX (These are large!)
-    lmodern \
    ## just because
     less \
     vim \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -37,12 +37,12 @@ RUN apt-get update \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && chown -R root:staff /opt/TinyTeX \
-  && chmod -R g+wx /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
   && tlmgr path add \
   && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
+  && chown -R root:staff /opt/TinyTeX \
+  && chmod -R g+wx /opt/TinyTeX \
  ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -27,32 +27,21 @@ RUN apt-get update \
     ssh \
     ## for building pdfs via pandoc/LaTeX (These are large!)
     lmodern \
-    texlive-fonts-recommended \
-    texlive-generic-recommended \
-    texlive-humanities \
-    texlive-latex-extra \
-    texlive-science \
-    texinfo \
-    ## just because
+   ## just because
     less \
     vim \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \
-  && cd /usr/share/texlive/texmf-dist/tex/latex \
-  ## additional tex files needed for certain rticles templates
-  && wget http://mirrors.ctan.org/macros/latex/contrib/ametsoc.zip \
-  && unzip ametsoc.zip \
-  && rm *.zip \
-## R manuals use inconsolata font, but texlive-fonts-extra is huge, so:
-  && cd /usr/share/texlive/texmf-dist \
-  && wget http://mirrors.ctan.org/install/fonts/inconsolata.tds.zip \
-  && unzip inconsolata.tds.zip \
-  && rm *.zip \
-  && echo "Map zi4.map" >> /usr/share/texlive/texmf-dist/web2c/updmap.cfg \
-  && mktexlsr \
-  && updmap-sys \
-  ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
-  && install2.r -r http://rforge.net PKI \
+  ## Use tinytex for LaTeX installation
+  && wget -qO- \
+    "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
+    sh -s - --admin --no-path \
+    && mv ~/.TinyTex /opt/TinyTex \
+    && chown -R root:staff /opt/TinyTex \
+    && /opt/TinyTeX/bin/*/tlmgr path add \
+    && tlmgr install metafont mfware inconsolata tex ae parskip listings \
+    && tlmgr path add \
+    && Rscript -e "source('https://install-github.me/yihui/tinytex'); tinytex::r_texmf()" \
   ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
   && chown -R root:staff /opt/TinyTeX \
-  && chmod g+wx /opt/TinyTeX \
+  && chmod -R g+wx /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
   && tlmgr path add \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
 ## Well here's a puzzle! This simple mv call doesn't work in `sh` shell, but works fine in bash shell.
 ## Amazingly, /bin/bash -c "mv ~/.TinyTex /opt/TinyTex" doesn't work either, but actually becoming 
 ## bash shell first and then running it works fine.  I'm stumped.  
-RUN mv ~/.TinyTex /opt/TinyTex \
+RUN mv ~/.TinyTeX /opt/TinyTex \
   && chown -R root:staff /opt/TinyTex \
   && /opt/TinyTeX/bin/*/tlmgr path add
  


### PR DESCRIPTION
This uses TinyTeX in place of texlive; the modular structure allows us to give users permission to install and manage tex libraries (including managing directly from R via the `tinytex` package) without root permissions.

This should make it easier for users to resolve problems of missing `.sty` files etc without resorting to a kitchen sink approach of pre-installing all such packages in this image.  See discussion in #59.  Big thanks to @yihui for making this possible.   