### PR TITLE
Add recommended packages to increase compatibility with packrat

### DIFF
--- a/r-ver/3.1.0/Dockerfile
+++ b/r-ver/3.1.0/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.2.0/Dockerfile
+++ b/r-ver/3.2.0/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.2.5/Dockerfile
+++ b/r-ver/3.2.5/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.3.0/Dockerfile
+++ b/r-ver/3.3.0/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.3.1/Dockerfile
+++ b/r-ver/3.3.1/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.3.2/Dockerfile
+++ b/r-ver/3.3.2/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.3.3/Dockerfile
+++ b/r-ver/3.3.3/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.4.0/Dockerfile
+++ b/r-ver/3.4.0/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.4.1/Dockerfile
+++ b/r-ver/3.4.1/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.4.2/Dockerfile
+++ b/r-ver/3.4.2/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.4.3/Dockerfile
+++ b/r-ver/3.4.3/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.4.4/Dockerfile
+++ b/r-ver/3.4.4/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.5.0/Dockerfile
+++ b/r-ver/3.5.0/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/3.5.1/Dockerfile
+++ b/r-ver/3.5.1/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \

--- a/r-ver/devel-san/Dockerfile
+++ b/r-ver/devel-san/Dockerfile
@@ -87,7 +87,7 @@ RUN apt-get update -qq \
      ./configure --enable-R-shlib \
                --with-blas \
                --with-readline \
-               --without-recommended-packages \
+               --with-recommended-packages \
                --program-suffix=dev \
                --disable-openmp \
   && make \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update \
                --with-blas \
                --with-tcltk \
                --disable-nls \
-               --without-recommended-packages \
+               --with-recommended-packages \
   ## Build and install
   && make \
   && make install \


### PR DESCRIPTION
closes #92 

All the rocker r-base/r-apt based images already have the R recommended
packages pre-installed, see e.g. [0].

By installing the recommended packages also on the r-ver based images the
compatibility with packrat is improved, when it is used in a mixed mode
on top of different distribution with recommended packages pre-installed
and r-ver based images. Packrat does not include recommended packages in
its package library packrat.lock, if those are in the system library,
see also the pakrat docu page 5 in [1]. This leads to unresolved
dependencies and would require manually adding those also to the packrat
library.

The R installer already includes a mechanism to also install the
recommended packages, which is just activated by this change. The R
recommended packages are also versioned by the R version, see [2]-[6].

[0] r-recommended: https://github.com/rocker-org/rocker/blob/master/r-base/Dockerfile#L50
[1] https://cran.r-project.org/web/packages/packrat/packrat.pdf
[2] https://cran.r-project.org/src/contrib/${R-Version}/Recommended/
[3] https://cran.r-project.org/src/contrib/3.5.1/Recommended/
[4] R_PKGS_RECOMMENDED: https://github.com/wch/r-source/blob/trunk/share/make/vars.mk
[5] https://github.com/wch/r-source/blob/trunk/src/library/Recommended/Makefile.in
[6] https://github.com/wch/r-source/blob/trunk/tools/rsync-recommended