### PR TITLE
Fix r-ver:devel/devel-san images by downloading R recommended pkgs src code

### DIFF
--- a/r-ver/devel-san/Dockerfile
+++ b/r-ver/devel-san/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update -qq \
     libx11-dev \
     libxt-dev \
     mpack \
+    rsync \
     subversion \
     tcl8.6-dev \
     texinfo \
@@ -64,6 +65,8 @@ RUN apt-get update -qq \
 ## Build and install according the standard 'recipe' I emailed/posted years ago
 ## Updated compiler flags to match https://www.stats.ox.ac.uk/pub/bdr/memtests/README.txt
   && cd /tmp/R-devel \
+  ## Get source code of recommended packages
+  && ./tools/rsync-recommended \
   && R_PAPERSIZE=letter \
      R_BATCHSAVE="--no-save --no-restore" \
      R_BROWSER=xdg-open \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update \
     libx11-dev \
     libxt-dev \
     perl \
+    rsync \
     subversion tcl8.6-dev \
     tk8.6-dev \
     texinfo \
@@ -78,6 +79,8 @@ RUN apt-get update \
   ## Extract source code
 
   && cd R-devel \
+  ## Get source code of recommended packages
+  && ./tools/rsync-recommended \
   ## Set compiler flags
   && R_PAPERSIZE=letter \
     R_BATCHSAVE="--no-save --no-restore" \


### PR DESCRIPTION
This was forgotten in the previous commit, where only the non-devel images where tested.