### PR TITLE
skip auth

### DIFF
--- a/rstudio/README.md
+++ b/rstudio/README.md
@@ -13,7 +13,16 @@ such as `rocker/tidyverse`.
 ## Common configuration options:
 
 
-#### Give the user root permissions (add to sudoers)
+### Use different versions of R
+
+    docker run -d -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:devel
+
+    docker run -d -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.2.0
+
+See [rocker/r-ver](https://github.com/rocker-org/rocker-versioned) for details.
+
+
+### Give the user root permissions (add to sudoers)
 
     docker run -d -p 8787:8787 -e ROOT=TRUE -e PASSWORD=yourpasswordhere rocker/rstudio
 
@@ -21,8 +30,30 @@ Link a local volume (in this example, the current working directory, `$(pwd)`) t
 
     docker run -d -p 8787:8787 -v $(pwd):/home/rstudio -e PASSWORD=yourpasswordhere rocker/rstudio
 
+### Bypassing the authentication step
 
-#### Add shiny server on start up with `e ADD=shiny`
+**Warning: use only in a secure environment**.  Do not use this approach on an
+AWS or other cloud machine with a publicly accessible IP address.  
+
+
+Create an `rserver.conf` script [like the example](rserver.conf) which has the
+line `auth-none=1`.  When running docker, map this script to overwrite
+`/etc/rstudio/rserver.conf` as shown below.  You will also need to set the
+environmental variable `USER=rstudio` at runtime, as shown.
+
+```
+docker run 
+  --rm -p 127.0.0.1:8787:8787
+  -e USER=rstudio 
+  -v $(pwd)/rstudio/rserver.conf:/etc/rstudio/rserver.conf 
+  rocker/rstudio
+```
+
+Navigate to <http://localhost:8787> and you should be logged into RStudio as
+the `rstudio` user without needing a password.
+
+
+### Add shiny server on start up with `e ADD=shiny`
 
     docker run -d -p 3838:3838 -p 8787:8787 -e ADD=shiny -e PASSWORD=yourpasswordhere rocker/rstudio
 
@@ -36,14 +67,9 @@ If you are building your own Dockerfiles on top of this stack, you should simply
 
 Then omit the `-e ADD=shiny` when running your image and shiny should be installed and waiting on port 3838.
 
+**Note**: Please see the `rocker/shiny` and `rocker/shiny-verse` images for
+setting up a shiny server in a separate container from RStudio. 
 
-#### Use different versions of R
-
-    docker run -d -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:devel
-
-    docker run -d -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.2.0
-
-See [rocker/r-ver](https://github.com/rocker-org/rocker-versioned) for details.
 
 #### Access a root shell for a running `rstudio` container instance
 
@@ -53,6 +79,7 @@ First, determine the name or id of your container (unless you provided a `--name
 
 You can now perform maintenance operations requiring root behavior such as `apt-get`, adding/removing users, etc.  
 
+Or, simply enable root as shown above and use the RStudio bash terminal.
 
 
 ## Additional configuration options
@@ -65,9 +92,6 @@ Custom uid/gid etc is usually only needed when sharing a local volume for a user
 
 
 Adding additional users:  From a root bash shell (see above), the usual debian linux commands can be used to create new users and passwords, e.g. 
-
-     
-
 
 ## Developers / Dockerfile authors
 

--- a/rstudio/rserver.conf
+++ b/rstudio/rserver.conf
@@ -1,0 +1,5 @@
+# Server Configuration File
+
+rsession-which-r=/usr/local/bin/R
+auth-none=1
+

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -10,7 +10,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     ## for rJava
     default-jdk \
     ## Nice Google fonts
-    fonts-roboto \    
+    fonts-roboto \
     ## used by some base R plots
     ghostscript \
     ## used to build rJava and other packages
@@ -25,11 +25,11 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     librdf0-dev \
     ## for V8-based javascript wrappers
     libv8-dev \
-    ## R CMD Check wants qpdf to check pdf sizes, or throws a Warning 
+    ## R CMD Check wants qpdf to check pdf sizes, or throws a Warning
     qpdf \
     ## For building PDF manuals
     texinfo \
-    ## for git via ssh key 
+    ## for git via ssh key
     ssh \
  ## just because
     less \
@@ -38,7 +38,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && rm -rf /var/lib/apt/lists/ \
   ## Use tinytex for LaTeX installation
   && install2.r --error tinytex \
-  && R -e "tinytex::install_tinytex(dir = '/opt/TinyTeX')" \ 
+  && R -e "tinytex::install_tinytex(dir = '/opt/TinyTeX')" \
   && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
   && tlmgr path add \
@@ -52,6 +52,6 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && install2.r --error --deps TRUE \
     bookdown rticles rmdshower
 #
-## Consider including: 
+## Consider including:
 # - yihui/printr R package (when released to CRAN)
 # - libgsl0-dev (GSL math library dependencies)


### PR DESCRIPTION
Do not insist on a password if authentication is turned off.  (Follow-up on #303)

@dinvlad  Can you take a look at this?  I think this creates the behavior you have recommended.  I've added an example `rserver.conf` to map, and when I test as follows:


```
docker build -t rstudio rstudio
docker run --rm -p 8787:8787 -v $(pwd)/rstudio/rserver.conf:/etc/rstudio/rserver.conf rstudio
```

This does bypass the error requested that enforces you to change the password and RStudio server comes up successfully with this in my testing.  However, I might be doing something wrong with the `rserver.conf` script since with this I'm still asked for a username and password once I connect, and no password works (though the container still has `rstudio` set as the default password).  I haven't used the `auth-none` option before to skip login, so maybe I'm missing something obvious here.  Thanks!