### PR TITLE
update Dockerfiles to use BiocManager instead of online R script

### DIFF
--- a/tidyverse/3.5.1/Dockerfile
+++ b/tidyverse/3.5.1/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libpq-dev \
   libssh2-1-dev \
   unixodbc-dev \
-  && R -e "source('https://bioconductor.org/biocLite.R')" \
   && install2.r --error \
     --deps TRUE \
     tidyverse \
@@ -18,5 +17,6 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     formatR \
     remotes \
     selectr \
-    caTools
+    caTools \
+    BiocManager
 

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libpq-dev \
   libssh2-1-dev \
   unixodbc-dev \
-  && R -e "source('https://bioconductor.org/biocLite.R')" \
   && install2.r --error \
     --deps TRUE \
     tidyverse \
@@ -18,6 +17,7 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     formatR \
     remotes \
     selectr \
-    caTools
+    caTools \
+    BiocManager
 
 # not clear why selectr needs explicit re-install, see https://github.com/rocker-org/rocker-versioned/pull/63

--- a/tidyverse/devel/Dockerfile
+++ b/tidyverse/devel/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libmariadb-client-lgpl-dev \
   libpq-dev \
   libssh2-1-dev \
-  && R -e "source('https://bioconductor.org/biocLite.R')" \
   && install2.r --error \
     --deps TRUE \
     tidyverse \
@@ -16,7 +15,8 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     devtools \
     formatR \
     remotes \
-    selectr
+    selectr \
+    BiocManager
 
 ## Notes: Above install2.r uses --deps TRUE to get Suggests dependencies as well,
 ## dplyr and ggplot are already part of tidyverse, but listed explicitly to get their (many) suggested dependencies.


### PR DESCRIPTION
Hi Carl, @cboettig 
Bioconductor is now using the `BiocManager` [CRAN package](https://cran.r-project.org/package=BiocManager) instead of an online R script (`https://bioconductor.org/biocLite.R`). I didn't find any R code using `biocLite`
but if you can point me to it, I'd be happy to change that too. Thanks!