### PR TITLE
fix partially-matched arg in install.packages call

### DIFF
--- a/r-ver/devel-san/Dockerfile
+++ b/r-ver/devel-san/Dockerfile
@@ -112,7 +112,7 @@ RUN apt-get update -qq \
   && export MRAN=$MRAN \
   ## MRAN becomes default only in versioned images
   ## Use littler installation scripts
-  && Rscript -e "install.packages(c('littler', 'docopt'), repo = '$MRAN')" \
+  && Rscript -e "install.packages(c('littler', 'docopt'), repos = '$MRAN')" \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \


### PR DESCRIPTION
Thanks for these great Dockerfiles. I'm a big fan of `rocker`!

I noticed a minor issue today while looking in `rocker-versioned` for reference. The install command you'll see in the diff uses `repo` instead of `repos` and I'm guessing it's been working because of R's lovely partially-match-keyword-args thing.

Please consider this PR to fix it.