### PR TITLE
installing RStudio Server v1.2

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
     python-setuptools \
     sudo \
     wget \
+    libclang-dev libclang-3.8-dev libobjc-6-dev libclang1-3.8 libclang-common-3.8-dev \
+    libllvm3.8 libllvm3.8 libobjc4 libgc1c2 \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \
-  && if [ -z "$RSTUDIO_VERSION" ]; then RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb"; else RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" fi \
+  && if [ -z "$RSTUDIO_VERSION" ]; then RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb"; else RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; fi \
   && wget -q $RSTUDIO_URL \
   && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -37,11 +37,7 @@ RUN apt-get update \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \
-  && if [ -z "$RSTUDIO_VERSION" ]; then \
-  RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" \
-  else \
-  RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb" \
-  fi \
+  && if [ -z "$RSTUDIO_VERSION" ]; then RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; else RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb"; fi \
   && wget -q $RSTUDIO_URL \
   && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -29,10 +29,13 @@ RUN apt-get update \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \
-  && RSTUDIO_LATEST=$(wget --no-check-certificate -qO- https://s3.amazonaws.com/rstudio-server/current.ver) \
-  && [ -z "$RSTUDIO_VERSION" ] && RSTUDIO_VERSION=$RSTUDIO_LATEST || true \
-  && wget -q http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \
-  && dpkg -i rstudio-server-${RSTUDIO_VERSION}-amd64.deb \
+  && if [ -z "$RSTUDIO_VERSION" ]; then \
+  RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" \
+  else \
+  RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb" \
+  fi \
+  && wget -q $RSTUDIO_URL \
+  && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \
   ## Symlink pandoc & standard pandoc templates for use system-wide
   && ln -s /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -26,8 +26,14 @@ RUN apt-get update \
     python-setuptools \
     sudo \
     wget \
-    libclang-dev libclang-3.8-dev libobjc-6-dev libclang1-3.8 libclang-common-3.8-dev \
-    libllvm3.8 libllvm3.8 libobjc4 libgc1c2 \
+    libclang-dev \
+    libclang-3.8-dev \
+    libobjc-6-dev \
+    libclang1-3.8 \
+    libclang-common-3.8-dev \
+    libllvm3.8 \
+    libobjc4 \
+    libgc1c2 \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb \
-  && if [ -z "$RSTUDIO_VERSION" ]; then RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; else RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb"; fi \
+  && if [ -z "$RSTUDIO_VERSION" ]; then RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/debian9_64/rstudio-server-latest-amd64.deb"; else RSTUDIO_URL="http://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" fi \
   && wget -q $RSTUDIO_URL \
   && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \


### PR DESCRIPTION
This fixes the issue described in #133 -- by updating the download URL of the most recent RStudio Server, and also adding the new dependencies introduced by the new version.

@cboettig, can you please check if I've updated the right file and let me know if I should do this update anywhere else or something looks bad. I've built this `Dockerfile` locally and seems to work fine.