### PR TITLE
Added version 3.2.4 to r-ver

### DIFF
--- a/r-ver/3.2.4/Dockerfile
+++ b/r-ver/3.2.4/Dockerfile
@@ -1,0 +1,139 @@
+FROM debian:jessie
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ARG R_VERSION
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE:-2016-03-10}
+ENV R_VERSION=${R_VERSION:-3.2.4} \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    TERM=xterm
+
+## dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash-completion \
+    ca-certificates curl \
+    file \
+    fonts-texgyre \
+    g++ \
+    gfortran \
+    gsfonts \
+    libblas-dev \
+    libbz2-1.0 \
+    libcurl3 \
+    libicu52 \
+    libjpeg62-turbo \
+    libopenblas-dev \
+    libpangocairo-1.0-0 \
+    libpcre3 \
+    libpng12-0 \
+    libtiff5 \
+    liblzma5 \
+    locales \
+    make \
+    unzip \
+    zip \
+    zlib1g \
+  && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+  && locale-gen en_US.utf8 \
+  && /usr/sbin/update-locale LANG=en_US.UTF-8 \
+  && BUILDDEPS="\
+    default-jdk \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libicu-dev \
+    libpcre3-dev \
+    libpng-dev \
+    libreadline-dev \
+    libtiff5-dev \
+    liblzma-dev \
+    libx11-dev \
+    libxt-dev \
+    perl \
+    tcl8.5-dev \
+    tk8.5-dev \
+    texinfo \
+    texlive-extra-utils \
+    texlive-fonts-recommended \
+    texlive-fonts-extra \
+    texlive-latex-recommended \
+    x11proto-core-dev \
+    xauth \
+    xfonts-base \
+    xvfb \
+    zlib1g-dev" \
+  && apt-get install -y --no-install-recommends $BUILDDEPS \
+  && cd tmp/ \
+  ## Download source code
+  && curl -O https://cran.r-project.org/src/base/R-3/R-${R_VERSION}.tar.gz \
+  ## Extract source code
+  && tar -xf R-${R_VERSION}.tar.gz \
+  && cd R-${R_VERSION} \
+  ## Set compiler flags
+  && R_PAPERSIZE=letter \
+    R_BATCHSAVE="--no-save --no-restore" \
+    R_BROWSER=xdg-open \
+    PAGER=/usr/bin/pager \
+    PERL=/usr/bin/perl \
+    R_UNZIPCMD=/usr/bin/unzip \
+    R_ZIPCMD=/usr/bin/zip \
+    R_PRINTCMD=/usr/bin/lpr \
+    LIBnn=lib \
+    AWK=/usr/bin/awk \
+    CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g" \
+    CXXFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g" \
+  ## Configure options
+  ./configure --enable-R-shlib \
+               --enable-memory-profiling \
+               --with-readline \
+               --with-blas \
+               --with-tcltk \
+               --disable-nls \
+               --with-recommended-packages \
+  ## Build and install
+  && make \
+  && make install \
+  ## Add a default CRAN mirror
+  && echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'curl')" >> /usr/local/lib/R/etc/Rprofile.site \
+  ## Add a library directory (for user-installed packages)
+  && mkdir -p /usr/local/lib/R/site-library \
+  && chown root:staff /usr/local/lib/R/site-library \
+  && chmod g+wx /usr/local/lib/R/site-library \
+  ## Fix library path
+  && echo "R_LIBS_USER='/usr/local/lib/R/site-library'" >> /usr/local/lib/R/etc/Renviron \
+  && echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron \
+  ## install packages from date-locked MRAN snapshot of CRAN
+  && [ -z "$BUILD_DATE" ] && BUILD_DATE=$(TZ="America/Los_Angeles" date -I) || true \
+  && MRAN=https://mran.microsoft.com/snapshot/${BUILD_DATE} \
+  && echo MRAN=$MRAN >> /etc/environment \
+  && export MRAN=$MRAN \
+  && echo "options(repos = c(CRAN='$MRAN'), download.file.method = 'curl')" >> /usr/local/lib/R/etc/Rprofile.site \
+  ## Use littler installation scripts
+  && Rscript -e "install.packages(c('littler', 'docopt'), repo = '$MRAN')" \
+  && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
+  && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
+  && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## make test
+  && make install-tests \
+  && cd $(R RHOME) \
+  && cd tests \
+  && ../bin/R CMD make check \
+  && R -e 'tools::testInstalledBasic("both")' \
+  ## Clean up from R source install
+  && cd / \
+  && rm -rf /tmp/* \
+  && apt-get remove --purge -y $BUILDDEPS \
+  && apt-get autoremove -y \
+  && apt-get autoclean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]
+

--- a/r-ver/3.2.4/hooks/post_push
+++ b/r-ver/3.2.4/hooks/post_push
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+# add additional tags without bugfix and minor version
+MAJ_MIN_BUG=${PWD##*/}
+MAJ_MIN=$(echo $MAJ_MIN_BUG | sed "s/\.[^\.]*$//")
+MAJ=$(echo $MAJ_MIN | sed "s/\.[^\.]*$//")
+
+echo "Add version tags for major and major.minor releases."
+
+## x.y.z
+# Tag for major.minor.bug is already provided by Docker Hub configuration
+
+## x.y
+# Check if this image is newest within major.minor
+NEWEST_MAJ_MIN=`ls ../ | grep "^$MAJ_MIN" | sort --version-sort | tail -n 1`
+if [ "$MAJ_MIN_BUG" == "$NEWEST_MAJ_MIN" ]
+then
+    echo "This version is also the newest major.minor version, add tag '$MAJ_MIN' to '$MAJ_MIN_BUG'"
+    docker tag $IMAGE_NAME $DOCKER_REPO:$MAJ_MIN
+    docker push $DOCKER_REPO:$MAJ_MIN
+else
+    echo "$NEWEST_MAJ_MIN is newest version starting with $MAJ_MIN, not tagging this one ($MAJ_MIN_BUG)."
+fi
+
+## x
+# Check if this image is "latest" within major
+NEWEST_MAJ=`ls ../ | grep "^$MAJ" | sort --version-sort | tail -n 1`
+if [ "$MAJ_MIN_BUG" == "$NEWEST_MAJ" ]
+then
+    echo "This version is also the newest major version, add tag '$MAJ' to '$MAJ_MIN_BUG'."
+    docker tag $IMAGE_NAME $DOCKER_REPO:$MAJ
+    docker push $DOCKER_REPO:$MAJ
+else
+    echo "$NEWEST_MAJ is newest version starting with $MAJ, not tagging this one ($MAJ_MIN_BUG)."
+fi
+
+## Get "latest": list parent directory files starting with number, sort them and only select the last one
+LATEST=`ls ../ | grep '^[0-9]' | sort --version-sort | tail -n 1`
+if [ "$MAJ_MIN_BUG" == "$LATEST" ]
+then
+    echo "This version is also newest version overall, add 'latest' tag to $MAJ_MIN_BUG"
+    docker tag $IMAGE_NAME $DOCKER_REPO:latest
+    docker push $DOCKER_REPO:latest
+else
+    echo "$LATEST is newest version overall, not tagging this one ($MAJ_MIN_BUG) with latest."
+fi
+
+echo "Version tagging completed."


### PR DESCRIPTION
Here is a Dockerfile for 3.2.4.

Based on the date from https://cran.r-project.org/src/base/R-3/
Used Jessie as a Debian distrib, as it was available on that date.

I reused the `Dockerfile` from 3.2.5 with these changes:
+ changed `ENV BUILD_DATE ${BUILD_DATE:-2016-03-10}`
+ changed `ENV R_VERSION=${R_VERSION:-3.2.4}`
+ Added installation tests at `#L124`, as suggested in [R Installation and Administration](https://cran.r-project.org/doc/manuals/R-admin.html#Testing-a-Unix_002dalike-Installation) to test that the install went as expected.