### PR TITLE
Added pdfcrop to rocker/verse

### DIFF
--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -47,7 +47,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
-  && tlmgr install metafont mfware inconsolata tex ae parskip listings \
+  && tlmgr install metafont mfware inconsolata tex ae parskip listings pdfcrop \
   && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -47,7 +47,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
-  && tlmgr install metafont mfware inconsolata tex ae parskip listings pdfcrop \
+  && tlmgr install ae inconsolata listings metafont mfware parskip pdfcrop tex \
   && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -47,7 +47,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
-  && tlmgr install metafont mfware inconsolata tex ae parskip listings \
+  && tlmgr install metafont mfware inconsolata tex ae parskip listings pdfcrop \
   && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -47,7 +47,7 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
   && /opt/TinyTeX/bin/*/tlmgr path add \
-  && tlmgr install metafont mfware inconsolata tex ae parskip listings pdfcrop \
+  && tlmgr install ae inconsolata listings metafont mfware parskip pdfcrop tex \
   && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \


### PR DESCRIPTION
Added `pdfcrop` to `rocker/verse` to support the default `fig_crop: true` of R Markdown with TinyTeX.
Updated both `verse/Dockerfile` and `verse/devel/Dockerfile` https://github.com/rocker-org/rocker-versioned/issues/146#issuecomment-492916714.

Note that installed LaTeX packages are now listed alphabetically, to allow easier maintenance and possible comparison to the [packages](https://github.com/yihui/tinytex/blob/master/tools/pkgs-custom.txt) part of the default TinyTeX installation (see [FAQ](https://yihui.name/tinytex/faq/)). One may consider removing them from the list .

No pdfcrop in the current `rocker/verse:latest`:

``` bash
docker pull rocker/verse:latest
docker run --rm rocker/verse:latest which pdfcrop
## latest: Pulling from rocker/verse
## Digest: sha256:4014cadbc8656390c5b77f9f5fedaf669b0411d696b18cd0c90dab5f9cb9a7b8
## Status: Image is up to date for rocker/verse:latest
```
`pdfcrop` available in the branch on the forked repo:
``` bash
CHECKOUT_DIR=/tmp/rocker-versioned
git clone -q -b verse-pdfcrop https://github.com/riccardoporreca/rocker-versioned.git $CHECKOUT_DIR
docker build -q -t rocker/verse:pdfcrop $CHECKOUT_DIR/verse
docker run --rm rocker/verse:pdfcrop which pdfcrop
rm -rf $CHECKOUT_DIR
## sha256:13c83dd4172cf3ad3b4ecb803f45acac8b8d7c18f21892b09c332a8b4689bb14
## /usr/local/bin/pdfcrop
```
