### PR TITLE
Let's support Chinese

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -38,6 +38,13 @@ RUN apt-get update \
   && wget -q $RSTUDIO_URL \
   && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \
+  ## Add Language Support for Chinese
+  && sed -i 's/# zh_CN.UTF-8 UTF-8/zh_CN.UTF-8 UTF-8/g' /etc/locale.gen
+  && locale-gen
+  && mkdir /usr/share/fonts/truetype/source
+  && wget -P /usr/share/fonts/truetype/source/ https://github.com/be5invis/source-han-sans-ttf/releases/download/v1.04.20170825/SourceHanSansSC-Regular.ttf
+  && fc-cache -vf
+  && fc-list
   ## Symlink pandoc & standard pandoc templates for use system-wide
   && ln -s /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin \
   && ln -s /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin \


### PR DESCRIPTION
R has a large fans in Chinese culture.
![Screen Shot 2019-06-28 at 08 55 58](https://user-images.githubusercontent.com/8103074/60309858-979da500-9982-11e9-8395-28f051a029a8.png)


But it's natively lack of the ability to display Chinese characters. In all plots, any CN char would be shown as a box with four digits.

In this PR, I add [Source Hans Sans](https://github.com/adobe-fonts/source-han-sans), a full-free font for Chinese, with a conversion of TTF by [be5invis](https://github.com/be5invis).
Hope rocker's version would be used more popular globally.

Thanks for [this tutorial](https://blog.llcat.tech/2018/12/03/add-zh-CN-locales-and-fonts-in-docker-images/)
Here are [my preview](https://hub.docker.com/r/haodong/verse-cn)