### PR TITLE
added system package devscripts to r-ver/devel Dockerfile

### DIFF
--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     bash-completion \
     ca-certificates \
     ccache \
+    devscripts \
     file \
     fonts-texgyre \
     g++ \


### PR DESCRIPTION
The system package devscripts contains the script checkbashisms which is now required by R CMD check --as-cran. Closes #166