### PR TITLE
Fix site-library permissions with debian:buster

### DIFF
--- a/r-ver/Dockerfile
+++ b/r-ver/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
   ## Add a library directory (for user-installed packages)
   && mkdir -p /usr/local/lib/R/site-library \
   && chown root:staff /usr/local/lib/R/site-library \
-  && chmod g+wx /usr/local/lib/R/site-library \
+  && chmod g+ws /usr/local/lib/R/site-library \
   ## Fix library path
   && sed -i '/^R_LIBS_USER=.*$/d' /usr/local/lib/R/etc/Renviron \
   && echo "R_LIBS_USER=\${R_LIBS_USER-'/usr/local/lib/R/site-library'}" >> /usr/local/lib/R/etc/Renviron \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -111,7 +111,7 @@ RUN apt-get update \
   ## Add a library directory (for user-installed packages)
   && mkdir -p /usr/local/lib/R/site-library \
   && chown root:staff /usr/local/lib/R/site-library \
-  && chmod g+wx /usr/local/lib/R/site-library \
+  && chmod g+ws /usr/local/lib/R/site-library \
   ## Fix library path
   && echo "R_LIBS_USER='/usr/local/lib/R/site-library'" >> /usr/local/lib/R/etc/Renviron \
   && echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron \

--- a/r-ver/devel/Dockerfile
+++ b/r-ver/devel/Dockerfile
@@ -61,7 +61,8 @@ RUN apt-get update \
     libxt-dev \
     perl \
     rsync \
-    subversion tcl8.6-dev \
+    subversion \
+    tcl8.6-dev \
     tk8.6-dev \
     texinfo \
     texlive-extra-utils \
@@ -126,9 +127,6 @@ RUN apt-get update \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
-  ## TEMPORARY WORKAROUND to get more robust error handling for install2.r prior to littler update
-  && curl -O /usr/local/bin/install2.r https://github.com/eddelbuettel/littler/raw/master/inst/examples/install2.r \
-  && chmod +x /usr/local/bin/install2.r \
   ## Clean up from R source install
   && cd / \
   && rm -rf /tmp/* \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -71,7 +71,6 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && (tlmgr path add || true) \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
-  && chown -R root:staff /usr/local/lib/R/site-library \
   && chmod -R g+w /opt/TinyTeX \
   && chmod -R g+wx /opt/TinyTeX/bin \
   && echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron \

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -72,7 +72,6 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && chmod -R g+w /opt/TinyTeX \
   && chmod -R g+wx /opt/TinyTeX/bin \
   && echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron \
-  ## Currently (2017-06-06) need devel PKI for ssl issue: https://github.com/s-u/PKI/issues/19
   && install2.r --error PKI \
   ## And some nice R packages for publishing-related stuff
   && install2.r --error --deps TRUE \

--- a/verse/devel/Dockerfile
+++ b/verse/devel/Dockerfile
@@ -69,7 +69,6 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
   && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
-  && chown -R root:staff /usr/local/lib/R/site-library \
   && chmod -R g+w /opt/TinyTeX \
   && chmod -R g+wx /opt/TinyTeX/bin \
   && echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron \


### PR DESCRIPTION
See #177 for background and discussions.

Updated `r-ver/devel` rebuilt locally as `rocker/r-ver:devel-site-library-g_ws`. Backported to the `latest` image (`3.6.1`) to be `buster`-ready.

Comparison of permissions versus existing `rocker/r-ver:devel` and `rocker/r-ver:3.6.1`

``` bash
test_site_library_mode() {
  docker run --rm rocker/$1 bash -c \
  'find /usr/local/lib/R/site-library* -ls -maxdepth 1'
}
for img in r-ver:devel r-ver:devel-site-library-g_ws \
           r-ver:3.6.1 r-ver:3.6.1-site-library-g_ws
do echo $img && test_site_library_mode $img; done
## r-ver:devel
##  13377366      4 drwxrwxr-x   4 root     staff        4096 Nov 24 22:36 /usr/local/lib/R/site-library
##  13377367      4 drwxrwxr-x   8 root     root         4096 Nov 24 22:36 /usr/local/lib/R/site-library/docopt
##  13377400      4 drwxrwxr-x  12 root     root         4096 Nov 24 22:36 /usr/local/lib/R/site-library/littler
## r-ver:devel-site-library-g_ws
##   5642717      4 drwxrwsr-x   4 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library
##   5642718      4 drwxrwxr-x   8 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library/docopt
##   5642751      4 drwxrwxr-x  12 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library/littler
## r-ver:3.6.1
##  12978538      4 drwxrwsr-x   4 root     staff        4096 Nov 24 22:33 /usr/local/lib/R/site-library
##  12978539      4 drwxrwxr-x   8 root     staff        4096 Nov 24 22:33 /usr/local/lib/R/site-library/docopt
##  12978572      4 drwxrwxr-x  12 root     staff        4096 Nov 24 22:33 /usr/local/lib/R/site-library/littler
## r-ver:3.6.1-site-library-g_ws
##   5120977      4 drwxrwsr-x   4 root     staff        4096 Dec  2 22:13 /usr/local/lib/R/site-library
##   5120978      4 drwxrwxr-x   8 root     staff        4096 Dec  2 22:13 /usr/local/lib/R/site-library/docopt
##   5121011      4 drwxrwxr-x  12 root     staff        4096 Dec  2 22:13 /usr/local/lib/R/site-library/littler
```

Similarly, for `rocker/rstudio:devel`, re-building locally based on the updated `rocker/r-ver:devel` fixes the permission issues as the `staff` group is now preserved:
``` bash
test_site_library_mode_rstudio_install() {
  docker run --rm --user rstudio rocker/$1 bash -c \
  'find /usr/local/lib/R/site-library* -ls -maxdepth 1 \
   && install2.r xfun docopt \
   && find /usr/local/lib/R/site-library* -ls -maxdepth 1'
}
for img in rstudio:devel rstudio:devel-site-library-g_ws
do echo $img && test_site_library_mode_rstudio_install $img; done
## rstudio:devel
##   8128063      4 drwxrwxr-x   4 root     staff        4096 Dec  3 01:48 /usr/local/lib/R/site-library
##   8128064      4 drwxrwxr-x   8 root     root         4096 Dec  3 01:48 /usr/local/lib/R/site-library/docopt
##   8128098      4 drwxrwxr-x  12 root     root         4096 Dec  3 01:48 /usr/local/lib/R/site-library/littler
## [...]
## * installing *source* package ‘xfun’ ...
## [...]
## * installing *source* package ‘docopt’ ...
## [...]
## mv: cannot move '/usr/local/lib/R/site-library/docopt' to '/usr/local/lib/R/site-library/00LOCK-docopt/docopt': Permission denied
## ERROR: cannot remove earlier installation, is it in use?
## [...]
##   8128063      4 drwxrwxr-x   1 root     staff        4096 Dec  4 00:08 /usr/local/lib/R/site-library
##   8128064      4 drwxrwxr-x   8 root     root         4096 Dec  3 01:48 /usr/local/lib/R/site-library/docopt
##   8128098      4 drwxrwxr-x  12 root     root         4096 Dec  3 01:48 /usr/local/lib/R/site-library/littler
##  12460546      4 drwxrwxr-x   7 rstudio  rstudio      4096 Dec  4 00:08 /usr/local/lib/R/site-library/xfun
## rstudio:devel-site-library-g_ws
##   5642717      4 drwxrwsr-x   4 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library
##   5642718      4 drwxrwxr-x   8 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library/docopt
##   5642751      4 drwxrwxr-x  12 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library/littler
## [...]
## * installing *source* package ‘xfun’ ...
## [...]
## * installing *source* package ‘docopt’ ...
## [...]
##   5642717      8 drwxrwsr-x   1 root     staff        4096 Dec  4 00:09 /usr/local/lib/R/site-library
##  12724692      4 drwxrwxr-x   8 rstudio  staff        4096 Dec  4 00:09 /usr/local/lib/R/site-library/docopt
##   5642751      4 drwxrwxr-x  12 root     staff        4096 Dec  2 23:08 /usr/local/lib/R/site-library/littler
##  12460546      4 drwxrwxr-x   7 rstudio  staff        4096 Dec  4 00:08 /usr/local/lib/R/site-library/xfun
```
Note that the example above for `rocker/rstudio:devel` reproduces the error in Bioconductor/bioconductor_full#17, based on which #177 was opened by @nturaga 