### PR TITLE
Patch error handling of tlmgr path in TeX Live 2016

### DIFF
--- a/verse/3.4.3/Dockerfile
+++ b/verse/3.4.3/Dockerfile
@@ -51,9 +51,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chmod -R g+w /opt/TinyTeX \

--- a/verse/3.4.4/Dockerfile
+++ b/verse/3.4.4/Dockerfile
@@ -51,9 +51,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chmod -R g+w /opt/TinyTeX \

--- a/verse/3.5.0/Dockerfile
+++ b/verse/3.5.0/Dockerfile
@@ -51,9 +51,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chown -R root:staff /usr/local/lib/R/site-library \

--- a/verse/3.5.1/Dockerfile
+++ b/verse/3.5.1/Dockerfile
@@ -51,9 +51,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chown -R root:staff /usr/local/lib/R/site-library \

--- a/verse/3.5.2/Dockerfile
+++ b/verse/3.5.2/Dockerfile
@@ -54,9 +54,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chown -R root:staff /usr/local/lib/R/site-library \

--- a/verse/3.5.3/Dockerfile
+++ b/verse/3.5.3/Dockerfile
@@ -54,9 +54,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chown -R root:staff /usr/local/lib/R/site-library \

--- a/verse/3.6.0/Dockerfile
+++ b/verse/3.6.0/Dockerfile
@@ -54,9 +54,20 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
     "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
     sh -s - --admin --no-path \
   && mv ~/.TinyTeX /opt/TinyTeX \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install -y --no-install-recommends patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chown -R root:staff /usr/local/lib/R/site-library \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -70,11 +70,12 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
       ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
       ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
       ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
-      apt-get update && apt-get install patch \
+      apt-get update && apt-get install -y --no-install-recommends patch \
       && wget -qO- \
          "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
          patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
-      && apt-get purge -y patch && apt-get clean; \
+      && apt-get remove --purge --autoremove -y patch \
+      && apt-get clean && rm -rf /var/lib/apt/lists/; \
     fi \
   && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install ae inconsolata listings metafont mfware parskip pdfcrop tex \

--- a/verse/Dockerfile
+++ b/verse/Dockerfile
@@ -66,9 +66,19 @@ RUN wget "https://travis-bin.yihui.name/texlive-local.deb" \
       && cp -Tr /tmp/install-tl-*/tlpkg/TeXLive /opt/TinyTeX/tlpkg/TeXLive \
       && rm -r /tmp/install-tl-*; \
     fi \
-  && (/opt/TinyTeX/bin/*/tlmgr path add || true) \
+  && if /opt/TinyTeX/bin/*/tex -v | grep -q 'TeX Live 2016'; then \
+      ## Patch error handling of tlmgr path (https://tex.stackexchange.com/a/314079)
+      ## in the frozen TeX Live 2016 snapshot by back-porting the corresponding fix:
+      ## https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e
+      apt-get update && apt-get install patch \
+      && wget -qO- \
+         "https://git.texlive.info/texlive/patch/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e" | \
+         patch -i - /opt/TinyTeX/tlpkg/TeXLive/TLUtils.pm \
+      && apt-get purge -y patch && apt-get clean; \
+    fi \
+  && /opt/TinyTeX/bin/*/tlmgr path add \
   && tlmgr install ae inconsolata listings metafont mfware parskip pdfcrop tex \
-  && (tlmgr path add || true) \
+  && tlmgr path add \
   && Rscript -e "tinytex::r_texmf()" \
   && chown -R root:staff /opt/TinyTeX \
   && chmod -R g+w /opt/TinyTeX \


### PR DESCRIPTION
* See https://tex.stackexchange.com/a/314079.
* Apply the corresponding fix https://git.texlive.info/texlive/commit/Master/tlpkg/TeXLive/TLUtils.pm?id=69cee5e1ce4b20f6ebb6af77e19d49706a842a3e instead of the `||true` workaround from #171.
* Fixes rocker-org/rocker#370.

See also https://github.com/rocker-org/rocker-versioned/pull/171#issuecomment-564755382 for an initial PoC the proposed patch is based on.