### PR TITLE
Remove R_LIBS_USER path placed in Renviron

### DIFF
--- a/r-ver/3.4.4.Dockerfile
+++ b/r-ver/3.4.4.Dockerfile
@@ -121,6 +121,8 @@ RUN apt-get update \
   && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
   && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
   && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## Remove fixed R_LIBS_USER library path
+  && sed -i '/^R_LIBS_USER=/ d' /usr/local/lib/R/etc/Renviron \
   ## Clean up from R source install
   && cd / \
   && rm -rf /tmp/* \


### PR DESCRIPTION
This PR proposes to remove the fixed `R_LIBS_USER` library path from the Renviron file. 

The motivation is twofold
1. It might be desirable for the users to be able to set the environment variable and have it recornized by R in the library paths as is the default behavior. Having it present in the Renviron file will however override the set environment variable, which is unexpected (unless the user studies the Dockerfile)
1.  Consistency with the `r-base` image which does not place a custom `R_LIBS_USER` into the Renviron file and therefore supports setting it as an evironment variable.


Example: 
```bash
docker run --rm -it rocker/r-ver:3.4.4 bash
```

Inside the container:

```bash
Rscript -e ".libPaths()"
mkdir testlib
export R_LIBS_USER=testlib
# testlib will not be considered:
Rscript -e ".libPaths()"
```

If this change is desired, can be included it for all the relevant r-ver Dockerfiles.