### PR TITLE
Use https to download the .deb file if RSTUDIO_VERSION is provided

### DIFF
--- a/rstudio/devel.Dockerfile
+++ b/rstudio/devel.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
     wget \
   && if [ -z "$RSTUDIO_VERSION" ]; \
     then RSTUDIO_URL="https://www.rstudio.org/download/latest/stable/server/bionic/rstudio-server-latest-amd64.deb"; \
-    else RSTUDIO_URL="http://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; fi \
+    else RSTUDIO_URL="https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"; fi \
   && wget -q $RSTUDIO_URL \
   && dpkg -i rstudio-server-*-amd64.deb \
   && rm rstudio-server-*-amd64.deb \


### PR DESCRIPTION
The link to download the .deb file should be via https.
Thanks