### PR TITLE
Add libpcre2-dev as it is needed by latest r-devel

### DIFF
--- a/r-ver/devel.Dockerfile
+++ b/r-ver/devel.Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
     libpango1.0-dev \
     libjpeg-dev \
     libicu-dev \
+    libpcre2-dev \
     libpcre3-dev \
     libpng-dev \
     libreadline-dev \


### PR DESCRIPTION
When the image is r-ver:devel is built without libpcre2-dev,
the following issue is generated.

```
checking whether PCRE support suffices... no
configure: error: PCRE2 library and headers are required, or use --with-pcre1 and PCRE >= 8.32 with UTF-8 support
/bin/sh: 1: Rscript: not found
```

This allows a clean build of rocker/r-ver:devel with R 4.0. 

It also addresses #197 which I opened.

