### PR TITLE
Remove libpcre3 as it causes a conflict while loading libraries

### DIFF
--- a/r-ver/devel.Dockerfile
+++ b/r-ver/devel.Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get update \
     libjpeg-dev \
     libicu-dev \
     libpcre2-dev \
-    libpcre3-dev \
     libpng-dev \
     libreadline-dev \
     libtiff5-dev \

--- a/r-ver/devel.Dockerfile
+++ b/r-ver/devel.Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update \
     libjpeg62-turbo \
     libopenblas-dev \
     libpangocairo-1.0-0 \
-    libpcre3 \
     libpng16-16 \
     libreadline7 \
     libtiff5 \


### PR DESCRIPTION
This seems to fix the issue caused when trying load R. 

```
docker run -it rocker/r-ver:devel bash

root@7c25d55d1fca:~# R
/usr/local/lib/R/bin/exec/R: error while loading shared libraries: libpcre2-8.so.0: cannot open shared object file: No such file or directory
```

This PR, tags on to https://github.com/rocker-org/rocker-versioned/pull/198. 