### PR TITLE
bug-fix: libpcre2-8-0 is needed along with libpcre2 for r-devel

### DIFF
--- a/r-ver/devel.Dockerfile
+++ b/r-ver/devel.Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     libbz2-1.0 \
     libcurl4 \
     libicu63 \
+    libpcre2-8-0 \
     libjpeg62-turbo \
     libopenblas-dev \
     libpangocairo-1.0-0 \


### PR DESCRIPTION
Without this library, the following error is produced

```
$$ docker run -it rocker/r-ver:devel bash
root@012af310be7d:/# R
/usr/local/lib/R/bin/exec/R: error while loading shared libraries: libpcre2-8.so.0: cannot open shared object file: No such file or directory
```

The same error doesn't show up in the rocker/rstudio and other
containers which inherit from this image is because another linux package is
installing the dependency libpcre2-8-0 on the succeeding images.

But for the rocker/r-ver:devel image to work, this dependency is needed.