### PR TITLE
Update the repo status from active to moved

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,6 @@
+---
+name: Tracking issue
+about: This repository is the source for R <= 3.6.3 images built before 2020-04; issues for R >= 4.0.0 images built after 2020-04 should be created in https://github.com/rocker-org/rocker-versioned2, not here.
+---
+
+<!-- This repository is the source for R <= 3.6.3 images built before 2020-04; issues for R >= 4.0.0 images built after 2020-04 should be created in https://github.com/rocker-org/rocker-versioned2, not here. -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CircleCI](https://circleci.com/gh/rocker-org/rocker-versioned.svg?style=svg)](https://circleci.com/gh/rocker-org/rocker-versioned)
 [![license](https://img.shields.io/badge/license-GPLv2-blue.svg)](https://opensource.org/licenses/GPL-2.0)
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
+[![Project Status: Moved to https://github.com/rocker-org/rocker-versioned2 – The project has been moved to a new location, and the version at that location should be considered authoritative.](https://www.repostatus.org/badges/latest/moved.svg)](https://www.repostatus.org/#moved) to [https://github.com/rocker-org/rocker-versioned2](https://github.com/rocker-org/rocker-versioned2)
 [![DOI](https://zenodo.org/badge/25048007.svg)](https://zenodo.org/badge/latestdoi/25048007)
 
 


### PR DESCRIPTION
Related to https://github.com/rocker-org/rocker-versioned2/pull/240

New work is being done in the new repository, so updating the badge may be more appropriate.
I thought `Moved` was the most appropriate.
https://www.repostatus.org/#moved